### PR TITLE
Add PayPal button partials to cart and product page

### DIFF
--- a/app/overrides/spree/components/cart/cart_items/insert_cart_buttons.rb
+++ b/app/overrides/spree/components/cart/cart_items/insert_cart_buttons.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "components/cart/cart_items/insert_cart_buttons",
+  virtual_path: "spree/components/cart/_cart_items",
+  original: "c15d7457875dbbce987638e26fe548e5b9415160",
+  insert_after: ".cart-items",
+  partial: 'solidus_paypal_commerce_platform/cart/cart_buttons'
+)

--- a/app/overrides/spree/components/products/product_submit/add_paypal_product_button.rb
+++ b/app/overrides/spree/components/products/product_submit/add_paypal_product_button.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "components/products/product_submit/add_paypal_product_button",
+  virtual_path: "spree/components/products/_product_submit",
+  insert_bottom: "#product-price",
+  original: "9897889a0aaff4f4f0c66600d7397f743d2e8bf7",
+  source: :partial,
+  partial: 'solidus_paypal_commerce_platform/product/product_buttons'
+)


### PR DESCRIPTION
The overrides we're using on SPCP are for the default solidus_frontend,
however here we're using the starter frontend. This provides overrides
for the new frontend style. We can probably just port these over to
SPCP once starter frontend officially takes over as the official frontend.