### PR TITLE
Override the pricing options cache key

### DIFF
--- a/app/models/solidus_demo/pricing_options.rb
+++ b/app/models/solidus_demo/pricing_options.rb
@@ -1,0 +1,5 @@
+class SolidusDemo::PricingOptions < Spree::Variant::PricingOptions
+  def cache_key
+    SolidusPaypalCommercePlatform::PaymentMethod.active.map(&:cache_key).sort + [super]
+  end
+end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -95,3 +95,7 @@ Spree.user_class = "Spree::LegacyUser"
 # the class name:
 #
 # Spree::UserLastUrlStorer.rules << 'Spree::UserLastUrlStorer::Rules::AuthenticationRule'
+
+def (Spree::Config).pricing_options_class
+  SolidusDemo::PricingOptions
+end


### PR DESCRIPTION
Otherwise the paypal button won't show up when the payment method is
added.